### PR TITLE
Update templatetag_handlebars.py

### DIFF
--- a/templatetag_handlebars/templatetags/templatetag_handlebars.py
+++ b/templatetag_handlebars/templatetags/templatetag_handlebars.py
@@ -1,6 +1,6 @@
 from django import template
 from django.conf import settings
-from django.utils import six
+import six
 
 register = template.Library()
 


### PR DESCRIPTION
updated six dependency as django version is deprecated in later versions